### PR TITLE
fix heroku support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
-from corona_api import __version__ as ver
+
+ver = '0.9.0.post1'
 
 with open('README.md', 'r') as f:
   long_desc = f.read()


### PR DESCRIPTION
0.9.0 causes the module to fail to install when on heroku (`no module named 'aiohttp'` even when aiohttp is installed). i dont know the details as to why but this PR fixes it nonetheless.